### PR TITLE
Fix new IT blocks ARMv8

### DIFF
--- a/include/core/SkFixed.h
+++ b/include/core/SkFixed.h
@@ -106,19 +106,9 @@ inline SkFixed SkFixedMul_longlong(SkFixed a, SkFixed b) {
     */
     SK_ALWAYS_INLINE SkFixed SkFloatToFixed_arm(float x)
     {
-        int32_t y, z;
-        asm("movs    %1, %3, lsl #1         \n"
-            "mov     %2, #0x8E              \n"
-            "sub     %1, %2, %1, lsr #24    \n"
-            "mov     %2, %3, lsl #8         \n"
-            "orr     %2, %2, #0x80000000    \n"
-            "mov     %1, %2, lsr %1         \n"
-            "it cs                          \n"
-            "rsbcs   %1, %1, #0             \n"
-            : "=r"(x), "=&r"(y), "=&r"(z)
-            : "r"(x)
-            : "cc"
-            );
+        int32_t y;
+        asm("vcvt.s32.f32 %0, %0, #16": "+w"(x));
+        memcpy(&y, &x, sizeof(y));
         return y;
     }
     inline SkFixed SkFixedMul_arm(SkFixed x, SkFixed y)


### PR DESCRIPTION
ARMv8 specifies that an IT block should be followed by only one 16-bit instruction.
* SkFloatToFix is back to a C implementation that mirrors the assembly code.

* S32A_D565_Opaque_neon switched the usage of the temporary 'ip' register to let
the compiler choose what is best in the context of the IT block. And replaced
'keep_dst' by 'ip' where low register or high register does not matter.

Edit: orginal commit changes include/private/SkFixed.h because the path changed
https://codereview.chromium.org/1839653002

BUG=skia:

CQ_INCLUDE_TRYBOTS=skia.primary:Test-Ubuntu-GCC-GCE-CPU-AVX2-x86_64-Release-SKNX_NO_SIMD

Change-Id: If587110a0c74b637ae99460419d46cf969c694fc
Reviewed-on: https://skia-review.googlesource.com/9346
Reviewed-by: Mike Klein <mtklein@chromium.org>
Commit-Queue: Mike Klein <mtklein@chromium.org>
Signed-off-by: lennart <lennart.1997@gmx.de>